### PR TITLE
Add RGBA support seperate from RGB support, this allows ignoring rgba…

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const {
 const {
   HEX_COLOR,
   RGB_COLOR,
+  RGBA_COLOR,
   HSL_COLOR,
   OKLAB_COLOR,
   OKLCH_COLOR,
@@ -62,8 +63,10 @@ module.exports = (options = {}) => {
               inputColorFormat = HEX_COLOR;
             } else if (!node.isHex && node.type === 'word') {
               inputColorFormat = KEYWORD_COLOR;
-            } else if (node.name === 'rgb' || node.name === 'rgba') {
+            } else if (node.name === 'rgb'){
               inputColorFormat = RGB_COLOR;
+            } else if (node.name === 'rgba') {
+              inputColorFormat = RGBA_COLOR;
             } else if (node.name === 'hsl' || node.name === 'hsla') {
               inputColorFormat = HSL_COLOR;
             } else if (node.name === 'oklab') {

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ module.exports = (options = {}) => {
               inputColorFormat = HEX_COLOR;
             } else if (!node.isHex && node.type === 'word') {
               inputColorFormat = KEYWORD_COLOR;
-            } else if (node.name === 'rgb'){
+            } else if (node.name === 'rgb') {
               inputColorFormat = RGB_COLOR;
             } else if (node.name === 'rgba') {
               inputColorFormat = RGBA_COLOR;

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,6 +3,7 @@ module.exports = {
   DEFAULT_ALPHA: 1,
   HEX_COLOR: 'hex',
   RGB_COLOR: 'rgb',
+  RGBA_COLOR: 'rgba',
   HSL_COLOR: 'hsl',
   OKLAB_COLOR: 'oklab',
   OKLCH_COLOR: 'oklch',

--- a/src/converts.js
+++ b/src/converts.js
@@ -3,6 +3,7 @@ const colorFn = require('colorizr');
 const {
   HEX_COLOR,
   RGB_COLOR,
+  RGBA_COLOR,
   HSL_COLOR,
   OKLAB_COLOR,
   OKLCH_COLOR,
@@ -18,6 +19,12 @@ const getFormattedString = (
   switch (outputFormat) {
     case HEX_COLOR:
       return alpha !== undefined ? colorFn.addAlphaToHex(colorData, alpha) : colorData;
+    case RGBA_COLOR:
+    case RGB_COLOR:
+      return isUseModernSyntax
+        ? `${outputFormat}${alpha !== undefined ? 'a' : ''}(${colorData.r} ${colorData.g} ${colorData.b}${alpha !== undefined ? ` / ${alpha}` : ''})`
+        : `${outputFormat}${alpha !== undefined ? 'a' : ''}(${colorData.r}, ${colorData.g}, ${colorData.b}${alpha !== undefined ? `, ${alpha}` : ''})`
+
     case RGB_COLOR:
       return isUseModernSyntax
         ? `${outputFormat}${alpha !== undefined ? 'a' : ''}(${colorData.r} ${colorData.g} ${colorData.b}${alpha !== undefined ? ` / ${alpha}` : ''})`
@@ -65,6 +72,7 @@ const convertColor = (node, inputColorFormat, options) => {
       }
 
       break;
+    case RGBA_COLOR:
     case RGB_COLOR:
       if (!isUseModernSyntax) {
         [c1, , c2, , c3, , alpha] = node.nodes;
@@ -76,6 +84,8 @@ const convertColor = (node, inputColorFormat, options) => {
 
       if (options.outputColorFormat === RGB_COLOR) {
         colorData = {r: +c1.value, g: +c2.value, b: +c3.value};
+      } else if (options.outputColorFormat === RGBA_COLOR){
+        colorData = {r: +c1.value, g: +c2.value, b: +c3.value, a: alpha};
       } else {
         colorData = colorFn[`rgb2${options.outputColorFormat}`]([+c1.value, +c2.value, +c3.value])
       }

--- a/src/converts.js
+++ b/src/converts.js
@@ -84,7 +84,7 @@ const convertColor = (node, inputColorFormat, options) => {
 
       if (options.outputColorFormat === RGB_COLOR) {
         colorData = {r: +c1.value, g: +c2.value, b: +c3.value};
-      } else if (options.outputColorFormat === RGBA_COLOR){
+      } else if (options.outputColorFormat === RGBA_COLOR) {
         colorData = {r: +c1.value, g: +c2.value, b: +c3.value, a: alpha};
       } else {
         colorData = colorFn[`rgb2${options.outputColorFormat}`]([+c1.value, +c2.value, +c3.value])

--- a/test/rgb.test.js
+++ b/test/rgb.test.js
@@ -149,6 +149,13 @@ describe('postcss-color-converter for rgb colors', function () {
     ), 'body { color: rgba(255, 255, 255, 1); }');
   });
 
+  it('Input color must ignore rgba', function () {
+    assert.equal(transform(
+      'body { color: rgba(255, 255, 255, 0.25); }',
+      { outputColorFormat: 'hex', ignore: ['rgba'] },
+    ), 'body { color: rgba(255, 255, 255, 0.25); }');
+  });
+
   it('Input color must be converted to hsl', function () {
     assert.equal(transform(
       'body { color: rgb(255, 255, 255); }',


### PR DESCRIPTION
Hi, this package is exactly what I need for some of the work I was doing.  Our project needed to make the distinction between RGB and RGBA.  We use RGBA to define transparent colors and only hex to define opaque colors.   

I forked this to get across a hurtle initially, but realized this could be a good addition if that's something you'd like to pull in.  I tried to copy the patterns already in the repo and only extended what I needed and re-used much of the RGB flow as possible.